### PR TITLE
add apt cookbook for apt-get update

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,5 @@
 site :opscode
 
+cookbook 'apt'
 cookbook 'build-essential'
 cookbook 'postgresql'

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Getting Started
 $ git clone git@github.com:Tomohiro/redmine-box.git
 $ cd redmine-box
 $ bundle install --path vendor/bundle
-$ bundle berks install --path cookbooks
+$ bundle exec berks install --path cookbooks
 ```
 
 

--- a/roles/redmine.rb
+++ b/roles/redmine.rb
@@ -1,6 +1,7 @@
 name 'redmine'
 description 'The base role for Redmine system'
 run_list(
+  'recipe[apt]',
   'recipe[build-essential]',
   'recipe[postgresql::server]',
   'recipe[openssl]'


### PR DESCRIPTION
I added apt cookbook to Berksfile and role/redmine.rb because `vagrant up` is failed like that.

`apt` cookbook exec `apt-get update` so `apt-get install postgresql-client` success after added it.

``` bash
[2013-04-12T09:20:35-03:00] INFO: Processing package[postgresql-client] action install (postgresql::client line 32)
================================================================================
Error executing action `install` on resource 'package[postgresql-client]'
================================================================================

Chef::Exceptions::Exec
----------------------
apt-get -q -y install postgresql-client=9.1+129ubuntu1 returned 100, expected 0

Resource Declaration:
---------------------
# In /tmp/vagrant-chef-1/chef-solo-1/cookbooks/postgresql/recipes/client.rb

 32:   package pg_pack
 33: 

Compiled Resource:
------------------
# Declared in /tmp/vagrant-chef-1/chef-solo-1/cookbooks/postgresql/recipes/client.rb:32:in `from_file'

package("postgresql-client") do
  retries 0
  recipe_name "client"
  cookbook_name :postgresql
  action :install
  package_name "postgresql-client"
  retry_delay 2
end

[2013-04-12T09:20:38-03:00] ERROR: Running exception handlers
[2013-04-12T09:20:38-03:00] ERROR: Exception handlers complete
[2013-04-12T09:20:38-03:00] FATAL: Stacktrace dumped to /tmp/vagrant-chef-1/chef-stacktrace.out
[2013-04-12T09:20:38-03:00] FATAL: Chef::Exceptions::Exec: package[postgresql-client] (postgresql::client line 32) had an error: Chef::Exceptions::Exec: apt-get -q -y install postgresql-client=9.1+129ubuntu1 returned 100, expected 0
Chef never successfully completed! Any errors should be visible in the
output above. Please fix your recipes so that they properly complete.
```
