### PR TITLE
test without edit ssh/config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,7 @@ Test
 --------------------------------------------------------------------------------
 
 ```sh
+$ vagrant up
+$ vagrant ssh-config >> ~/.ssh/config
 $ bundle exec rake spec
 ```

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ RSpec.configure do |c|
   c.include(Serverspec::Helper::Ssh)
   c.include(Serverspec::Helper::Debian)
   c.before do
-    host  = File.basename(Pathname.new(example.metadata[:location]).dirname)
+    host = `vagrant ssh-config | grep "^Host" | cut -d' ' -f2`
     if c.host != host
       c.ssh.close if c.ssh
       c.host  = host


### PR DESCRIPTION
I fixed spec_helper.rb to exec serverspec below 3 steps.

``` bash
$ vagrant up
$ vagrant ssh-config >> ~/.ssh/config
$ bundle exec rake spec
```

Unfortunately, changing Host default to other is not supported now on vagrant.
https://github.com/mitchellh/vagrant/issues/1395
