### PR TITLE
vagrant ssh-config が任意のホスト名指定可能だった

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,28 @@ $ bundle exec berks install --path cookbooks
 Test
 --------------------------------------------------------------------------------
 
+Add Vagrant ssh configuration to the your `~/.ssh/config`.
+
+```sh
+$ vagrant ssh-config --host redmine-box >> ~/.ssh/config
+```
+
+Or edit your `~/.ssh/config` by hand like this.
+
+```
+Host redmine-box
+    User vagrant
+    HostName 127.0.0.1
+    Port 2222
+    UserKnownHostsFile /dev/null
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    IdentityFile ~/.vagrant.d/insecure_private_key
+    IdentitiesOnly yes
+    LogLevel FATAL
+```
+
 ```sh
 $ vagrant up
-$ vagrant ssh-config >> ~/.ssh/config
 $ bundle exec rake spec
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ bundle exec berks install --path cookbooks
 Test
 --------------------------------------------------------------------------------
 
-Add Vagrant ssh configuration to the your `~/.ssh/config`.
+Add Vagrant ssh configuration to your `~/.ssh/config`.
 
 ```sh
 $ vagrant ssh-config --host redmine-box >> ~/.ssh/config

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,11 +3,11 @@ require 'pathname'
 require 'net/ssh'
 
 RSpec.configure do |c|
-  c.sudo_password = ENV['SUDO_PASSWORD']
   c.include(Serverspec::Helper::Ssh)
   c.include(Serverspec::Helper::Debian)
+
   c.before do
-    host = `vagrant ssh-config | grep "^Host" | cut -d' ' -f2`
+    host  = File.basename(Pathname.new(example.metadata[:location]).dirname)
     if c.host != host
       c.ssh.close if c.ssh
       c.host  = host
@@ -16,5 +16,4 @@ RSpec.configure do |c|
       c.ssh   = Net::SSH.start(c.host, user, options)
     end
   end
-
 end


### PR DESCRIPTION
自分の勘違いだったんですが、以下の書式で ssh-config のホスト名指定可能でした

``` bash
$ vagrant ssh-config --host HOSTNAME
```

※ Vagrantfile 内で指定できないのが微妙といえば微妙

なので、`vagrant ssh-config --host redmine-box >> ~/.ssh/config` とかやれば #3  の変更は必要ないのかなーと思いました。

現行の状態だと redmine-box のようなプロジェクトを複数持ってる場合に .ssh/config 内で default が潰されるので、他のプロジェクトとバッティングしないかなーというのも気になってます。

というわけで、 #3 の変更を戻そうと思うんですがいかがでしょうか。
